### PR TITLE
Point all API URLs to staging for testnet release

### DIFF
--- a/api-reference/compute/area.mdx
+++ b/api-reference/compute/area.mdx
@@ -38,7 +38,7 @@ POST /compute/v0/area
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/area \
+curl -X POST https://staging-api.astral.global/compute/v0/area \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -49,7 +49,7 @@ curl -X POST https://api.astral.global/compute/v0/area \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/area', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/area', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/compute/contains.mdx
+++ b/api-reference/compute/contains.mdx
@@ -42,7 +42,7 @@ POST /compute/v0/contains
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/contains \
+curl -X POST https://staging-api.astral.global/compute/v0/contains \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -54,7 +54,7 @@ curl -X POST https://api.astral.global/compute/v0/contains \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/contains', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/contains', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/compute/distance.mdx
+++ b/api-reference/compute/distance.mdx
@@ -42,7 +42,7 @@ POST /compute/v0/distance
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/distance \
+curl -X POST https://staging-api.astral.global/compute/v0/distance \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -57,7 +57,7 @@ curl -X POST https://api.astral.global/compute/v0/distance \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/distance', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/distance', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/compute/intersects.mdx
+++ b/api-reference/compute/intersects.mdx
@@ -42,7 +42,7 @@ POST /compute/v0/intersects
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/intersects \
+curl -X POST https://staging-api.astral.global/compute/v0/intersects \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -54,7 +54,7 @@ curl -X POST https://api.astral.global/compute/v0/intersects \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/intersects', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/intersects', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/compute/length.mdx
+++ b/api-reference/compute/length.mdx
@@ -38,7 +38,7 @@ POST /compute/v0/length
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/length \
+curl -X POST https://staging-api.astral.global/compute/v0/length \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -49,7 +49,7 @@ curl -X POST https://api.astral.global/compute/v0/length \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/length', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/length', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/compute/within.mdx
+++ b/api-reference/compute/within.mdx
@@ -46,7 +46,7 @@ POST /compute/v0/within
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/compute/v0/within \
+curl -X POST https://staging-api.astral.global/compute/v0/within \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -59,7 +59,7 @@ curl -X POST https://api.astral.global/compute/v0/within \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/compute/v0/within', {
+const response = await fetch('https://staging-api.astral.global/compute/v0/within', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -34,8 +34,8 @@ Astral provides two REST APIs for working with location proofs and geospatial da
 ## Base URLs
 
 ```
-https://api.astral.global/verify/v0
-https://api.astral.global/compute/v0
+https://staging-api.astral.global/verify/v0
+https://staging-api.astral.global/compute/v0
 ```
 
 ## Authentication

--- a/api-reference/verify/plugins.mdx
+++ b/api-reference/verify/plugins.mdx
@@ -20,12 +20,12 @@ GET /verify/v0/plugins
 <CodeGroup>
 
 ```bash cURL
-curl https://api.astral.global/verify/v0/plugins \
+curl https://staging-api.astral.global/verify/v0/plugins \
   -H "X-API-Key: your-api-key"
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/verify/v0/plugins', {
+const response = await fetch('https://staging-api.astral.global/verify/v0/plugins', {
   headers: { 'X-API-Key': 'your-api-key' }
 });
 

--- a/api-reference/verify/proof.mdx
+++ b/api-reference/verify/proof.mdx
@@ -38,7 +38,7 @@ POST /verify/v0/proof
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/verify/v0/proof \
+curl -X POST https://staging-api.astral.global/verify/v0/proof \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -84,7 +84,7 @@ curl -X POST https://api.astral.global/verify/v0/proof \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/verify/v0/proof', {
+const response = await fetch('https://staging-api.astral.global/verify/v0/proof', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/api-reference/verify/stamp.mdx
+++ b/api-reference/verify/stamp.mdx
@@ -28,7 +28,7 @@ POST /verify/v0/stamp
 <CodeGroup>
 
 ```bash cURL
-curl -X POST https://api.astral.global/verify/v0/stamp \
+curl -X POST https://staging-api.astral.global/verify/v0/stamp \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-api-key" \
   -d '{
@@ -55,7 +55,7 @@ curl -X POST https://api.astral.global/verify/v0/stamp \
 ```
 
 ```typescript TypeScript
-const response = await fetch('https://api.astral.global/verify/v0/stamp', {
+const response = await fetch('https://staging-api.astral.global/verify/v0/stamp', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/guides/agent-integration.mdx
+++ b/guides/agent-integration.mdx
@@ -31,7 +31,7 @@ Astral is a REST API, so any language or framework that can make HTTP requests w
 ```python
 import httpx
 
-response = httpx.post("https://api.astral.global/compute/distance", json={
+response = httpx.post("https://staging-api.astral.global/compute/distance", json={
     "from": {"type": "Point", "coordinates": [2.2945, 48.8584]},
     "to": {"type": "Point", "coordinates": [2.3522, 48.8566]},
     "chainId": 84532
@@ -44,7 +44,7 @@ distance_meters = result["result"]
 ### TypeScript
 
 ```typescript
-const response = await fetch('https://api.astral.global/compute/distance', {
+const response = await fetch('https://staging-api.astral.global/compute/distance', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
@@ -76,7 +76,7 @@ else:
 For boolean operations like containment or intersection, the result is `true` or `false`:
 
 ```python
-response = httpx.post("https://api.astral.global/compute/contains", json={
+response = httpx.post("https://staging-api.astral.global/compute/contains", json={
     "container": geofence_polygon,
     "geometry": {"type": "Point", "coordinates": agent_location},
     "chainId": 84532
@@ -100,7 +100,7 @@ Here is a complete agent workflow that checks whether a courier has arrived at t
 import httpx
 import time
 
-ASTRAL_URL = "https://api.astral.global"
+ASTRAL_URL = "https://staging-api.astral.global"
 DELIVERY_RADIUS_METERS = 100
 
 def check_delivery_proximity(

--- a/guides/calling-the-api.mdx
+++ b/guides/calling-the-api.mdx
@@ -13,7 +13,7 @@ This guide covers the mechanics of making requests to Astral — how to format i
 
 | Environment | URL |
 |-------------|-----|
-| Production | `https://api.astral.global` |
+| Staging (testnet) | `https://staging-api.astral.global` |
 | Local development | `http://localhost:3004` |
 
 See [Local development](/guides/local-development) for setup instructions.
@@ -146,7 +146,7 @@ Errors follow [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details f
 
 ```json
 {
-  "type": "https://api.astral.global/errors/invalid-input",
+  "type": "https://staging-api.astral.global/errors/invalid-input",
   "title": "Invalid Input",
   "status": 400,
   "detail": "Field 'from' must be a valid GeoJSON geometry or attestation UID"
@@ -166,7 +166,7 @@ Errors follow [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details f
 ### Handling errors in code
 
 ```typescript
-const response = await fetch('https://api.astral.global/compute/distance', {
+const response = await fetch('https://staging-api.astral.global/compute/distance', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
@@ -189,7 +189,7 @@ console.log(`Distance: ${result.result} ${result.units}`);
 ## Full example: curl
 
 ```bash
-curl -X POST https://api.astral.global/compute/contains \
+curl -X POST https://staging-api.astral.global/compute/contains \
   -H "Content-Type: application/json" \
   -d '{
     "container": {

--- a/guides/verifying-location-proofs.mdx
+++ b/guides/verifying-location-proofs.mdx
@@ -113,7 +113,7 @@ const result = await astral.verify.proof(proof);
 Or via raw HTTP:
 
 ```bash
-curl -X POST https://api.astral.global/verify/proof \
+curl -X POST https://staging-api.astral.global/verify/proof \
   -H "Content-Type: application/json" \
   -d '{
     "claim": {

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -65,7 +65,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 
 const astral = new AstralSDK({
   chainId: 84532,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // 1. Collect signals from a proof-of-location plugin on the device

--- a/plugins/mock.mdx
+++ b/plugins/mock.mdx
@@ -149,7 +149,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Register MockPlugin

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -18,7 +18,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 
 const astral = new AstralSDK({
   chainId: 84532,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // 1. Collect raw signals from a proof-of-location plugin on the device
@@ -124,7 +124,7 @@ const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 const result = await astral.compute.within({

--- a/resources/staging.mdx
+++ b/resources/staging.mdx
@@ -39,8 +39,21 @@ curl -X POST https://staging-api.astral.global/compute/v0/distance \
   }'
 ```
 
+## Verifying signatures
+
+All attestations from the staging service are signed by the attester address above. To verify a result came from Astral's staging environment:
+
+```solidity
+require(attestation.attester == 0x590fdb53ed3f0B52694876d42367192a5336700F, "Not from Astral staging");
+```
+
+```typescript
+const ASTRAL_STAGING_SIGNER = '0x590fdb53ed3f0B52694876d42367192a5336700F';
+// Verify the EAS attestation's attester field matches
+```
+
 ## Notes
 
 - No authentication required
 - Rate limited to 100 requests/hour per IP
-- Attestations are signed but use a staging key (not production)
+- Attestations are signed with the staging key — a different key will be used for production

--- a/sdk/compute.mdx
+++ b/sdk/compute.mdx
@@ -17,7 +17,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Access via astral.compute
@@ -440,7 +440,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Create a location attestation

--- a/sdk/eas.mdx
+++ b/sdk/eas.mdx
@@ -65,7 +65,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Compute a policy check

--- a/sdk/installation.mdx
+++ b/sdk/installation.mdx
@@ -49,7 +49,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // All modules are available
@@ -70,7 +70,7 @@ import { ProofModePlugin } from '@location-proofs/plugin-proofmode';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Register plugins before using stamps/proofs
@@ -94,7 +94,7 @@ const network = await provider.getNetwork();
 const astral = new AstralSDK({
   chainId: Number(network.chainId),
   signer: signer,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 ```
 
@@ -111,7 +111,7 @@ const provider = new ethers.JsonRpcProvider('https://sepolia.base.org');
 const astral = new AstralSDK({
   chainId: 84532,
   provider: provider,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Can verify attestations
@@ -137,7 +137,7 @@ interface AstralConfig {
   /** Ethers provider for read-only blockchain operations. */
   provider?: Provider;
 
-  /** Astral API base URL. Defaults to 'https://api.astral.global' */
+  /** Astral API base URL. Defaults to 'https://staging-api.astral.global' */
   apiUrl?: string;
 
   /** Required for TEE verification and hosted stamp verification. */
@@ -221,7 +221,7 @@ For server-side applications:
 # .env
 PRIVATE_KEY=0x...
 CHAIN_ID=84532
-ASTRAL_API_URL=https://api.astral.global
+ASTRAL_API_URL=https://staging-api.astral.global
 ```
 
 ```typescript

--- a/sdk/location-proofs.mdx
+++ b/sdk/location-proofs.mdx
@@ -17,7 +17,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Access via astral.proofs
@@ -335,7 +335,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 astral.plugins.register(new MockPlugin({

--- a/sdk/migration.mdx
+++ b/sdk/migration.mdx
@@ -69,7 +69,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Access modules via namespaces
@@ -227,7 +227,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 const result = await astral.compute.within(
@@ -286,7 +286,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Create location

--- a/sdk/overview.mdx
+++ b/sdk/overview.mdx
@@ -29,7 +29,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global',
+  apiUrl: 'https://staging-api.astral.global',
   apiKey: 'your-api-key'
 });
 
@@ -91,7 +91,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Create an offchain location attestation
@@ -125,7 +125,7 @@ interface AstralConfig {
   // Recommended
   signer?: Signer;              // For signing attestations and transactions
   provider?: Provider;          // For read-only blockchain operations
-  apiUrl?: string;              // Defaults to 'https://api.astral.global'
+  apiUrl?: string;              // Defaults to 'https://staging-api.astral.global'
   apiKey?: string;              // Required for TEE verification and hosted endpoints
 
   // Advanced

--- a/sdk/stamps.mdx
+++ b/sdk/stamps.mdx
@@ -17,7 +17,7 @@ import { AstralSDK } from '@decentralized-geo/astral-sdk';
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Access via astral.stamps
@@ -281,7 +281,7 @@ const wallet = new ethers.Wallet(process.env.PRIVATE_KEY);
 const astral = new AstralSDK({
   chainId: 84532,
   signer: wallet,
-  apiUrl: 'https://api.astral.global'
+  apiUrl: 'https://staging-api.astral.global'
 });
 
 // Register a plugin

--- a/sdk/types.mdx
+++ b/sdk/types.mdx
@@ -14,7 +14,7 @@ Core TypeScript types exported by `@decentralized-geo/astral-sdk`.
 ```typescript
 interface AstralSDKConfig {
   chainId: number;                // Target chain ID (e.g., 84532 for Base Sepolia)
-  apiUrl?: string;                // API base URL (default: https://api.astral.global)
+  apiUrl?: string;                // API base URL (default: https://staging-api.astral.global)
   signer?: ethers.Signer;        // Ethers signer for onchain submissions
 }
 ```


### PR DESCRIPTION
## Summary

- Replace all `api.astral.global` references with `staging-api.astral.global` across 24 docs pages
- Add signature verification examples to staging page with attester address `0x590fdb53ed3f0B52694876d42367192a5336700F`
- Label the API environment as "Staging (testnet)" instead of "Production" in the calling-the-api guide

## Context

This is a testnet release — `api.astral.global` doesn't exist yet. All docs should point to what developers can actually use right now.

## Test plan

- [ ] Verify no remaining `api.astral.global` references (except openclaw which is unlinked)
- [ ] Staging page shows attester address and verification examples
- [ ] All code snippets compile with the updated URL