### PR TITLE
docs(privacy): link design issue (#65) + correct overstated TEE privacy claims

### DIFF
--- a/concepts/privacy.mdx
+++ b/concepts/privacy.mdx
@@ -41,7 +41,7 @@ To be clear: Astral does not offer private inputs or private outputs as features
 - **Shielded outputs** — return a policy decision (trigger / don't trigger) carrying no identifying detail about who or where.
 - **Encrypted outputs** — results encrypted so only a specified counterparty can read them.
 
-The output-stripping piece is tracked in [astral-location-services#57](https://github.com/AstralProtocol/astral-location-services/issues/57); the broader set is being collected. If any of this matters to you, [get in touch](mailto:contact@astral.global).
+The output-stripping piece is tracked in [astral-location-services#57](https://github.com/AstralProtocol/astral-location-services/issues/57); the broader design is collected in [astral-location-services#65](https://github.com/AstralProtocol/astral-location-services/issues/65). If any of this matters to you, [get in touch](mailto:contact@astral.global).
 
 ## Information Leakage From Results
 


### PR DESCRIPTION
Follow-up to #31. The final commit linking the new privacy-design issue (astral-location-services#65) didn't make it into the squash merge, so the privacy page still says 'the broader set is being collected' with no link. This adds the link. One line.