### PR TITLE
docs: surface the policy-evaluation layer and reconcile attestation terminology

### DIFF
--- a/concepts/compute.mdx
+++ b/concepts/compute.mdx
@@ -69,6 +69,20 @@ Every compute operation returns a [signed result](/concepts/signed-results) cont
 
 The signed result can be used offchain (in an agent, application, or database) or submitted onchain via EAS delegated attestation. EAS resolvers allow those attestations to trigger smart contract logic.
 
+## Zones and policy evaluation
+
+A predicate operation — `contains`, `within`, `intersects` — is a policy decision. "Is this verified position inside the permitted zone?" is at once a spatial question and a rule, and the boolean answer is the verdict. Astral evaluates the rule inside the TEE and signs the verdict; the application — or a resolver contract — decides what the verdict triggers.
+
+### Zones as reusable, verifiable references
+
+The boundary in a policy check doesn't have to travel with every request. Because any input can be a [signed location record](#accepted-inputs) — an EAS attestation UID — you can register a zone once as a [Location attestation](/resources/schemas#location-attestation-schema) and reference it by UID thereafter. Astral fetches the stored geometry into the TEE at evaluation time.
+
+That gives you a reusable registry of zones — permitted corridors, jurisdictional boundaries, geofences — without a bespoke registry service. The boundary's provenance and integrity come from its attestation, and every evaluation references the exact same geometry by UID, so a policy decision is reproducible and auditable: anyone can confirm *which* zone was checked.
+
+### From verdict to action
+
+Submitted onchain, a [Policy Attestation](/concepts/signed-results) carrying a `true`/`false` verdict can drive an [EAS resolver](/concepts/signed-results#using-signed-results-onchain) — releasing escrow, granting access, gating a mint to inside a boundary. The spatial rule is evaluated offchain in the TEE; only the signed verdict and the on-chain action it triggers touch the chain.
+
 ## What's Next
 
 The current operation set covers the most common spatial questions, but PostGIS exposes a much larger surface. Areas we're exploring:

--- a/concepts/signed-results.mdx
+++ b/concepts/signed-results.mdx
@@ -9,6 +9,10 @@ description: "Output formats from verification and computation — and how to us
 
 Both the [Verify](/concepts/verify) and [Compute](/concepts/compute) endpoints return signed results — cryptographically signed records of what was computed, what inputs were used, and what the answer was. The signature comes from the Astral signing key, held inside the [TEE](/concepts/astral-location-services).
 
+<Info>
+  **"Signed result" and "Policy Attestation" are the same artifact.** "Signed result" is the conceptual name used throughout these docs; **Policy Attestation** is its concrete encoded form — the [EAS schema](/resources/schemas#policy-attestation-schemas) the result is serialized into (`BooleanPolicyAttestation` for predicates, `NumericPolicyAttestation` for measurements). A signed result submitted to EAS *is* a Policy Attestation. The SDK, the schemas reference, and the API use "Policy Attestation" for the on-chain object; the concept pages say "signed result" for the same thing.
+</Info>
+
 ## What a Signed Result Proves
 
 Under attestation (see deployment status below), a signed result is intended to prove three things:

--- a/how-it-works.mdx
+++ b/how-it-works.mdx
@@ -49,6 +49,8 @@ The output is a **credibility vector**: structured scores quantifying how well t
 
 Run geospatial operations — distance, containment, intersection, area, length — on location data inside the Astral TEE. The compute endpoints accept raw GeoJSON, signed location records, or verified location proofs as inputs. [PostGIS](https://postgis.net/) (backed by the [GEOS](https://libgeos.org/) library, the same computational geometry engine used by QGIS and other open-source geospatial tools) performs the computation; the TEE signs the result.
 
+A predicate operation is also a **policy decision**: "is this verified position inside the permitted zone?" is a rule, and the signed boolean is the verdict. Zones can be passed inline or referenced by EAS UID — a reusable, verifiable registry of boundaries — and the verdict can drive an on-chain resolver. See [zones and policy evaluation](/concepts/compute#zones-and-policy-evaluation).
+
 <Tip>
   **Why this step matters:** Verifiable spatial answers. The signed result proves not just "what was the answer" but "the answer was computed correctly by trusted code on these specific inputs."
 </Tip>


### PR DESCRIPTION
## Why

The docs are accurate about *what's built* and honestly scoped, but two things make them read as a **geocomputation oracle** rather than what Astral actually is — verifiable location proofs **plus a policy-evaluation engine with an EAS-based zone registry that triggers on-chain action**. Both surfaced while watching an AI agent build a wrong mental model from `llms-full.txt`:

1. **The output artifact has two names that are never reconciled.** The concept pages say "signed result"; the schemas reference, SDK, and API say "Policy Attestation." Same object, never connected — so it reads as two things.
2. **The policy-evaluation capability is real but never named or framed.** Predicate-as-policy-decision, zone-by-EAS-UID, and resolver-triggering are each documented in isolation; nothing connects them into the capability they add up to. The zone registry in particular lives in a single input-table row and is never called a registry.

These are framing/consistency gaps, **not** factual corrections — nothing here overclaims maturity, and every statement is already true of the system.

## Changes

- **`concepts/signed-results.mdx`** — short note pinning "signed result" (the concept) and "Policy Attestation" (its concrete EAS-encoded form) to one artifact.
- **`concepts/compute.mdx`** — new "Zones and policy evaluation" section: predicate result = policy verdict; EAS UID = reusable, verifiable zone registry with no bespoke service; signed verdict → on-chain resolver, with the rule evaluated offchain in the TEE.
- **`how-it-works.mdx`** — one line in the pipeline surfacing the policy-evaluation framing on the most-read page, linking to the new section.

Two atomic commits (terminology; framing). All internal anchors verified against existing headings. Prose-only, matches existing voice and MDX components.

## Note on scope

This is the bounded subset of a larger docs-accuracy idea — the highest-leverage pieces that close the specific gaps that mislead a skimming reader (human or agent). Larger follow-ups (a per-component build-status table, an adversarial "summarize the docs and check against ground truth" QA step) are deliberately left out.